### PR TITLE
Update SoftwareSerial.h and .cpp with One Pin Only Mode

### DIFF
--- a/libraries/SoftwareSerial/src/SoftwareSerial.cpp
+++ b/libraries/SoftwareSerial/src/SoftwareSerial.cpp
@@ -272,22 +272,35 @@ void SoftwareSerial::setTX(uint8_t tx)
   // the pin would be output low for a short while before switching to
   // output high. Now, it is input with pullup for a short while, which
   // is fine. With inverse logic, either order is fine.
-  digitalWrite(tx, _inverse_logic ? LOW : HIGH);
-  pinMode(tx, OUTPUT);
-  _transmitBitMask = digitalPinToBitMask(tx);
-  uint8_t port = digitalPinToPort(tx);
-  _transmitPortRegister = portOutputRegister(port);
+  if (tx == DISABLED_PIN) {
+    // If tx pin mapped as unused, flag is on and skip pin setup.
+    _txDisabled = true;
+  }
+  else {
+    _txDisabled = false;
+    digitalWrite(tx, _inverse_logic ? LOW : HIGH);
+    pinMode(tx, OUTPUT);
+    _transmitBitMask = digitalPinToBitMask(tx);
+    uint8_t port = digitalPinToPort(tx);
+    _transmitPortRegister = portOutputRegister(port);
+  }
 }
 
 void SoftwareSerial::setRX(uint8_t rx)
 {
-  pinMode(rx, INPUT);
-  if (!_inverse_logic)
-    digitalWrite(rx, HIGH);  // pullup for normal logic!
-  _receivePin = rx;
-  _receiveBitMask = digitalPinToBitMask(rx);
-  uint8_t port = digitalPinToPort(rx);
-  _receivePortRegister = portInputRegister(port);
+   if (rx == DISABLED_PIN) {
+     _rxDisabled = true;
+   }
+   else {
+     _rxDisabled = false;
+     pinMode(rx, INPUT);
+     if (!_inverse_logic)
+        digitalWrite(rx, HIGH);  // pullup for normal logic!
+      _receivePin = rx;
+     _receiveBitMask = digitalPinToBitMask(rx);
+     uint8_t port = digitalPinToPort(rx);
+     _receivePortRegister = portInputRegister(port);
+   }
 }
 
 uint16_t SoftwareSerial::subtract_cap(uint16_t num, uint16_t sub) {
@@ -315,63 +328,74 @@ void SoftwareSerial::begin(long speed)
   // timings are the most critical (deviations stack 8 times)
   _tx_delay = subtract_cap(bit_delay, 15 / 4);
 
-  // Only setup rx when we have a valid PCINT for this pin
-  if (digitalPinToPCICR((int8_t)_receivePin)) {
-    #if GCC_VERSION > 40800
-    // Timings counted from gcc 4.8.2 output. This works up to 115200 on
-    // 16Mhz and 57600 on 8Mhz.
-    //
-    // When the start bit occurs, there are 3 or 4 cycles before the
-    // interrupt flag is set, 4 cycles before the PC is set to the right
-    // interrupt vector address and the old PC is pushed on the stack,
-    // and then 75 cycles of instructions (including the RJMP in the
-    // ISR vector table) until the first delay. After the delay, there
-    // are 17 more cycles until the pin value is read (excluding the
-    // delay in the loop).
-    // We want to have a total delay of 1.5 bit time. Inside the loop,
-    // we already wait for 1 bit time - 23 cycles, so here we wait for
-    // 0.5 bit time - (71 + 18 - 22) cycles.
-    _rx_delay_centering = subtract_cap(bit_delay / 2, (4 + 4 + 75 + 17 - 23) / 4);
+  // If only RX pin is enabled
+  if (!_rxDisabled) {
+    // Only setup rx when we have a valid PCINT for this pin
+    if (digitalPinToPCICR((int8_t)_receivePin)) {
+      #if GCC_VERSION > 40800
+      // Timings counted from gcc 4.8.2 output. This works up to 115200 on
+      // 16Mhz and 57600 on 8Mhz.
+      //
+      // When the start bit occurs, there are 3 or 4 cycles before the
+      // interrupt flag is set, 4 cycles before the PC is set to the right
+      // interrupt vector address and the old PC is pushed on the stack,
+      // and then 75 cycles of instructions (including the RJMP in the
+      // ISR vector table) until the first delay. After the delay, there
+      // are 17 more cycles until the pin value is read (excluding the
+      // delay in the loop).
+      // We want to have a total delay of 1.5 bit time. Inside the loop,
+      // we already wait for 1 bit time - 23 cycles, so here we wait for
+      // 0.5 bit time - (71 + 18 - 22) cycles.
+      _rx_delay_centering = subtract_cap(bit_delay / 2, (4 + 4 + 75 + 17 - 23) / 4);
 
-    // There are 23 cycles in each loop iteration (excluding the delay)
-    _rx_delay_intrabit = subtract_cap(bit_delay, 23 / 4);
+      // There are 23 cycles in each loop iteration (excluding the delay)
+      _rx_delay_intrabit = subtract_cap(bit_delay, 23 / 4);
 
-    // There are 37 cycles from the last bit read to the start of
-    // stopbit delay and 11 cycles from the delay until the interrupt
-    // mask is enabled again (which _must_ happen during the stopbit).
-    // This delay aims at 3/4 of a bit time, meaning the end of the
-    // delay will be at 1/4th of the stopbit. This allows some extra
-    // time for ISR cleanup, which makes 115200 baud at 16Mhz work more
-    // reliably
-    _rx_delay_stopbit = subtract_cap(bit_delay * 3 / 4, (37 + 11) / 4);
-    #else // Timings counted from gcc 4.3.2 output
-    // Note that this code is a _lot_ slower, mostly due to bad register
-    // allocation choices of gcc. This works up to 57600 on 16Mhz and
-    // 38400 on 8Mhz.
-    _rx_delay_centering = subtract_cap(bit_delay / 2, (4 + 4 + 97 + 29 - 11) / 4);
-    _rx_delay_intrabit = subtract_cap(bit_delay, 11 / 4);
-    _rx_delay_stopbit = subtract_cap(bit_delay * 3 / 4, (44 + 17) / 4);
-    #endif
+      // There are 37 cycles from the last bit read to the start of
+      // stopbit delay and 11 cycles from the delay until the interrupt
+      // mask is enabled again (which _must_ happen during the stopbit).
+      // This delay aims at 3/4 of a bit time, meaning the end of the
+      // delay will be at 1/4th of the stopbit. This allows some extra
+      // time for ISR cleanup, which makes 115200 baud at 16Mhz work more
+      // reliably
+      _rx_delay_stopbit = subtract_cap(bit_delay * 3 / 4, (37 + 11) / 4);
+      #else // Timings counted from gcc 4.3.2 output
+      // Note that this code is a _lot_ slower, mostly due to bad register
+      // allocation choices of gcc. This works up to 57600 on 16Mhz and
+      // 38400 on 8Mhz.
+      _rx_delay_centering = subtract_cap(bit_delay / 2, (4 + 4 + 97 + 29 - 11) / 4);
+      _rx_delay_intrabit = subtract_cap(bit_delay, 11 / 4);
+      _rx_delay_stopbit = subtract_cap(bit_delay * 3 / 4, (44 + 17) / 4);
+      #endif
 
 
-    // Enable the PCINT for the entire port here, but never disable it
-    // (others might also need it, so we disable the interrupt by using
-    // the per-pin PCMSK register).
-    *digitalPinToPCICR((int8_t)_receivePin) |= _BV(digitalPinToPCICRbit(_receivePin));
-    // Precalculate the pcint mask register and value, so setRxIntMask
-    // can be used inside the ISR without costing too much time.
-    _pcint_maskreg = digitalPinToPCMSK(_receivePin);
-    _pcint_maskvalue = _BV(digitalPinToPCMSKbit(_receivePin));
+      // Enable the PCINT for the entire port here, but never disable it
+      // (others might also need it, so we disable the interrupt by using
+      // the per-pin PCMSK register).
+      *digitalPinToPCICR((int8_t)_receivePin) |= _BV(digitalPinToPCICRbit(_receivePin));
+      // Precalculate the pcint mask register and value, so setRxIntMask
+      // can be used inside the ISR without costing too much time.
+      _pcint_maskreg = digitalPinToPCMSK(_receivePin);
+      _pcint_maskvalue = _BV(digitalPinToPCMSKbit(_receivePin));
 
-    tunedDelay(_tx_delay); // if we were low this establishes the end
+      tunedDelay(_tx_delay); // if we were low this establishes the end
+    }
   }
 
 #if _DEBUG
   pinMode(_DEBUG_PIN1, OUTPUT);
   pinMode(_DEBUG_PIN2, OUTPUT);
 #endif
-
-  listen();
+  
+  // If tx is disabled, then TX delay is reset
+  if (_txDisabled) {
+    _tx_delay = 0;
+  }
+   
+  // If only RX pin is not disabled, start listen this port
+  if (!_rxDisabled) {
+    listen();
+  }
 }
 
 void SoftwareSerial::setRxIntMsk(bool enable)

--- a/libraries/SoftwareSerial/src/SoftwareSerial.h
+++ b/libraries/SoftwareSerial/src/SoftwareSerial.h
@@ -67,6 +67,10 @@ private:
 
   uint16_t _buffer_overflow:1;
   uint16_t _inverse_logic:1;
+  
+  // pin disabled mode (only one pin is used Rx or Tx)
+  bool _rxDisabled;
+  bool _txDisabled;
 
   // static data
   static uint8_t _receive_buffer[_SS_MAX_RX_BUFF]; 

--- a/libraries/SoftwareSerial/src/SoftwareSerial.h
+++ b/libraries/SoftwareSerial/src/SoftwareSerial.h
@@ -47,6 +47,8 @@ http://arduiniana.org.
 #define GCC_VERSION (__GNUC__ * 10000 + __GNUC_MINOR__ * 100 + __GNUC_PATCHLEVEL__)
 #endif
 
+#define DISABLED_PIN 255 // Number that disabled one pin
+
 class SoftwareSerial : public Stream
 {
 private:


### PR DESCRIPTION
Making SoftwareSerial object to create one pin mode that either Rx or Tx pin. It can handy when there are lack of pins for both Rx and Tx, and only one pin Rx or Tx is necessary in the project.

For that we will make bool flag for rx and tx that which pin is disabled.